### PR TITLE
Feature: don't cap bevy framerate when out of focus

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -379,10 +379,9 @@ fn bevy_loop(
 	);
 
 	if flatscreenmode {
-			app.insert_resource(WinitSettings {
+		app.insert_resource(WinitSettings {
 			focused_mode: UpdateMode::Continuous,
 			unfocused_mode: UpdateMode::Continuous,
-			..Default::default()
 		});
 	}
 


### PR DESCRIPTION
Bevy's default behavior limits the framerate when the window is out of focus. Does not seem relevant for our use case, especially during debugging and profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically enables flatscreen mode when a desktop display environment is detected.
  * Ensures continuous updates in flatscreen mode even when the app window is unfocused, improving smoothness.
  * Improves input handling for flatscreen mode for a more responsive desktop experience.

* **Refactor**
  * Centralizes flatscreen mode detection behind a single environment-aware flag to streamline initialization and plugin setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->