### PR TITLE
Create flatscreen VK device with required extensions for dmabuf use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "bevy-dmabuf"
 version = "0.2.0"
-source = "git+https://github.com/Schmarni-Dev/bevy-dmabuf#7f0a4a35f7f84d34c0a604c41e3f382b8cebf0aa"
+source = "git+https://github.com/Schmarni-Dev/bevy-dmabuf#4dc77184620bfa3c9dbc4d1a1baef33501506242"
 dependencies = [
  "ash",
  "bevy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn bevy_loop(
 		} else {
 			// enable a event
 			plugins = plugins.add(XrSessionPlugin { auto_handle: false });
-			bevy_dmabuf::wgpu_init::add_dmabuf_init_plugin(plugins)
+			bevy_dmabuf::wgpu_init::add_dmabuf_init_plugin(plugins, vk_device_exts())
 		}
 		.set(WindowPlugin {
 			primary_window: Some(Window {


### PR DESCRIPTION
Companion PR to https://github.com/Schmarni-Dev/bevy-dmabuf/pull/3.